### PR TITLE
Test files added

### DIFF
--- a/tests/test_utils/test_key.py
+++ b/tests/test_utils/test_key.py
@@ -1,0 +1,79 @@
+"""Tests for key generation utilities."""
+from pocket_cache.utils.key import generate_key
+
+
+def test_generate_key_basic():
+    """Test basic key generation."""
+    key = generate_key("test", "func", (), {})
+    assert key == "test:func"
+
+
+def test_generate_key_with_args():
+    """Test key generation with positional arguments."""
+    key = generate_key("test", "func", (1, "two", 3.0), {})
+    assert "test:func" in key
+    assert '[1, "two", 3.0]' in key
+
+
+def test_generate_key_with_kwargs():
+    """Test key generation with keyword arguments."""
+    key = generate_key("test", "func", (), {"a": 1, "b": 2})
+    assert "test:func" in key
+    assert '{"a": 1, "b": 2}' in key
+
+
+def test_generate_key_with_args_and_kwargs():
+    """Test key generation with both args and kwargs."""
+    key = generate_key("test", "func", (1, 2), {"a": 3, "b": 4})
+    assert "test:func" in key
+    assert "[1, 2]" in key
+    assert '{"a": 3, "b": 4}' in key
+
+
+def test_generate_key_empty_prefix():
+    """Test key generation with empty prefix."""
+    key = generate_key("", "func", (1,), {})
+    assert key == ":func:[1]"
+
+
+def test_generate_key_none_values():
+    """Test key generation with None values."""
+    key = generate_key("test", "func", (None,), {"null": None})
+    assert "test:func" in key
+    assert "[null]" in key
+    assert '{"null": null}' in key
+
+
+def test_generate_key_nested_structures():
+    """Test key generation with nested data structures."""
+    args = ([1, 2, {"inner": [3, 4]}],)
+    kwargs = {"dict": {"a": [1, 2], "b": {"c": 3}}}
+    key = generate_key("test", "func", args, kwargs)
+    assert "test:func" in key
+    assert "inner" in key
+    assert "dict" in key
+
+
+def test_generate_key_long_key():
+    """Test key generation with very long input that requires hashing."""
+    long_string = "x" * 300
+    key = generate_key("test", "func", (long_string,), {})
+    assert len(key) == 64  # SHA-256 hexdigest length
+    assert all(c in "0123456789abcdef" for c in key)
+
+
+def test_generate_key_special_characters():
+    """Test key generation with special characters."""
+    key = generate_key("test", "func", ("!@#$%^&*",), {"key:with:colons": "value"})
+    assert "test:func" in key
+    assert "!@#$%^&*" in key
+    assert "key:with:colons" in key
+
+
+def test_generate_key_unicode():
+    """Test key generation with Unicode characters."""
+    key = generate_key("test", "func", ("你好",), {"emoji": "🐍"})
+    assert "test:func" in key
+    # Check for escaped Unicode sequences
+    assert "\\u4f60\\u597d" in key  # Escaped form of "你好"
+    assert "\\ud83d\\udc0d" in key  # Escaped form of "🐍"

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -1,1 +1,64 @@
- 
+"""Tests for validation utilities."""
+from datetime import timedelta
+
+import pytest
+
+from pocket_cache.utils.validation import validate_ttl
+
+
+def test_validate_ttl_none():
+    """Test that None TTL is handled correctly."""
+    assert validate_ttl(None) is None
+
+
+def test_validate_ttl_positive_int():
+    """Test positive integer TTL."""
+    result = validate_ttl(60)
+    assert isinstance(result, timedelta)
+    assert result.total_seconds() == 60
+
+
+def test_validate_ttl_zero_int():
+    """Test zero integer TTL."""
+    result = validate_ttl(0)
+    assert isinstance(result, timedelta)
+    assert result.total_seconds() == 0
+
+
+def test_validate_ttl_negative_int():
+    """Test that negative integer TTL raises ValueError."""
+    with pytest.raises(ValueError, match="TTL cannot be negative"):
+        validate_ttl(-1)
+
+
+def test_validate_ttl_positive_timedelta():
+    """Test positive timedelta TTL."""
+    td = timedelta(minutes=5)
+    result = validate_ttl(td)
+    assert result == td
+
+
+def test_validate_ttl_zero_timedelta():
+    """Test zero timedelta TTL."""
+    td = timedelta()
+    result = validate_ttl(td)
+    assert result == td
+
+
+def test_validate_ttl_negative_timedelta():
+    """Test that negative timedelta TTL raises ValueError."""
+    td = timedelta(seconds=-1)
+    with pytest.raises(ValueError, match="TTL cannot be negative"):
+        validate_ttl(td)
+
+
+def test_validate_ttl_invalid_type():
+    """Test that invalid TTL type raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid TTL type"):
+        validate_ttl("60")  # type: ignore
+
+
+def test_validate_ttl_float():
+    """Test that float TTL raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid TTL type"):
+        validate_ttl(60.0)  # type: ignore


### PR DESCRIPTION
Added test files
/Users/vinny/Projects/pycache/pocket-cache/venv/lib/python3.13/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================ test session starts =================================================
platform darwin -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0 -- /Users/vinny/Projects/pycache/pocket-cache/venv/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/vinny/Projects/pycache/pocket-cache
configfile: pyproject.toml
testpaths: tests
plugins: cov-6.0.0, asyncio-0.25.3, xdist-3.6.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None
collected 37 items                                                                                                   

tests/test_backends/test_memory.py::test_memory_backend_set_get PASSED                                         [  2%]
tests/test_backends/test_memory.py::test_memory_backend_expiration PASSED                                      [  5%]
tests/test_backends/test_memory.py::test_memory_backend_delete PASSED                                          [  8%]
tests/test_cache.py::test_basic_operations PASSED                                                              [ 10%]
tests/test_cache.py::test_ttl PASSED                                                                           [ 13%]
tests/test_cache.py::test_clear PASSED                                                                         [ 16%]
tests/test_cache.py::test_cached_decorator PASSED                                                              [ 18%]
tests/test_cache.py::test_cache_set_get PASSED                                                                 [ 21%]
tests/test_cache.py::test_cache_ttl PASSED                                                                     [ 24%]
tests/test_cache.py::test_cache_delete PASSED                                                                  [ 27%]
tests/test_cache.py::test_cache_clear PASSED                                                                   [ 29%]
tests/test_cache.py::test_cache_default_value PASSED                                                           [ 32%]
tests/test_decorators.py::test_cached_decorator PASSED                                                         [ 35%]
tests/test_decorators.py::test_cached_decorator_different_args PASSED                                          [ 37%]
tests/test_decorators.py::test_cached_decorator_expiration PASSED                                              [ 40%]
tests/test_serializers/test_json.py::test_json_serializer_string PASSED                                        [ 43%]
tests/test_serializers/test_json.py::test_json_serializer_dict PASSED                                          [ 45%]
tests/test_serializers/test_json.py::test_json_serializer_list PASSED                                          [ 48%]
tests/test_utils/test_key.py::test_generate_key_basic PASSED                                                   [ 51%]
tests/test_utils/test_key.py::test_generate_key_with_args PASSED                                               [ 54%]
tests/test_utils/test_key.py::test_generate_key_with_kwargs PASSED                                             [ 56%]
tests/test_utils/test_key.py::test_generate_key_with_args_and_kwargs PASSED                                    [ 59%]
tests/test_utils/test_key.py::test_generate_key_empty_prefix PASSED                                            [ 62%]
tests/test_utils/test_key.py::test_generate_key_none_values PASSED                                             [ 64%]
tests/test_utils/test_key.py::test_generate_key_nested_structures PASSED                                       [ 67%]
tests/test_utils/test_key.py::test_generate_key_long_key PASSED                                                [ 70%]
tests/test_utils/test_key.py::test_generate_key_special_characters PASSED                                      [ 72%]
tests/test_utils/test_key.py::test_generate_key_unicode PASSED                                                 [ 75%]
tests/test_utils/test_validation.py::test_validate_ttl_none PASSED                                             [ 78%]
tests/test_utils/test_validation.py::test_validate_ttl_positive_int PASSED                                     [ 81%]
tests/test_utils/test_validation.py::test_validate_ttl_zero_int PASSED                                         [ 83%]
tests/test_utils/test_validation.py::test_validate_ttl_negative_int PASSED                                     [ 86%]
tests/test_utils/test_validation.py::test_validate_ttl_positive_timedelta PASSED                               [ 89%]
tests/test_utils/test_validation.py::test_validate_ttl_zero_timedelta PASSED                                   [ 91%]
tests/test_utils/test_validation.py::test_validate_ttl_negative_timedelta PASSED                               [ 94%]
tests/test_utils/test_validation.py::test_validate_ttl_invalid_type PASSED                                     [ 97%]
tests/test_utils/test_validation.py::test_validate_ttl_float PASSED                                            [100%]

---------- coverage: platform darwin, python 3.13.1-final-0 ----------
Name                                    Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------
src/pocket_cache/__init__.py                5      0      0      0   100%
src/pocket_cache/backends/__init__.py       3      0      0      0   100%
src/pocket_cache/backends/base.py          14      0      0      0   100%
src/pocket_cache/backends/memory.py        28      0      4      0   100%
src/pocket_cache/cache.py                  49      1     10      2    95%   75->78, 115
src/pocket_cache/serializers/base.py        7      0      0      0   100%
src/pocket_cache/serializers/json.py       15      4      0      0    73%   30-31, 48-49
src/pocket_cache/utils/__init__.py          3      0      0      0   100%
src/pocket_cache/utils/decorators.py       22      0      4      1    96%   23->26
src/pocket_cache/utils/key.py              15      0      6      0   100%
src/pocket_cache/utils/validation.py       14      0     10      0   100%
-----------------------------------------------------------------------------------
TOTAL                                     175      5     34      3    96%
Coverage XML written to file coverage.xml


================================================= 37 passed in 4.83s =================================================